### PR TITLE
Admin Improvements

### DIFF
--- a/code/datums/keybinding/admin.dm
+++ b/code/datums/keybinding/admin.dm
@@ -2,7 +2,6 @@
 	category = CATEGORY_ADMIN
 	weight = WEIGHT_ADMIN
 
-/*
 /datum/keybinding/admin/admin_say
 	hotkey_keys = list("F3")
 	name = "admin_say"
@@ -12,7 +11,7 @@
 /datum/keybinding/admin/admin_say/down(client/user)
 	user.get_admin_say()
 	return TRUE
-
+	
 /datum/keybinding/admin/admin_ghost
 	hotkey_keys = list("F5")
 	name = "admin_ghost"
@@ -33,16 +32,6 @@
 	user.holder.player_panel_new()
 	return TRUE
 
-/datum/keybinding/admin/toggle_buildmode_self
-	hotkey_keys = list("F7")
-	name = "toggle_buildmode_self"
-	full_name = "Toggle Buildmode Self"
-	description = "Toggles buildmode"
-
-/datum/keybinding/admin/toggle_buildmode_self/down(client/user)
-	user.togglebuildmodeself()
-	return TRUE
-
 /datum/keybinding/admin/stealthmode
 	hotkey_keys = list("CtrlF8")
 	name = "stealth_mode"
@@ -51,6 +40,16 @@
 
 /datum/keybinding/admin/stealthmode/down(client/user)
 	user.stealth()
+	return TRUE
+/*
+/datum/keybinding/admin/toggle_buildmode_self
+	hotkey_keys = list("F7")
+	name = "toggle_buildmode_self"
+	full_name = "Toggle Buildmode Self"
+	description = "Toggles buildmode"
+
+/datum/keybinding/admin/toggle_buildmode_self/down(client/user)
+	user.togglebuildmodeself()
 	return TRUE
 
 /datum/keybinding/admin/invisimin

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -298,7 +298,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 		return FALSE
 
 	var/mob/dead/observer/observer	// Transfer safety to observer spawning proc.
-	if(check_rights(R_ADMIN, FALSE))
+	if(check_rights(R_WATCH, FALSE))
 		observer = new /mob/dead/observer/admin(src)
 	else
 		observer = new /mob/dead/observer/rogue(src)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -298,7 +298,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 		return FALSE
 
 	var/mob/dead/observer/observer	// Transfer safety to observer spawning proc.
-	if(check_rights(R_WATCH, FALSE))
+	if(check_rights(R_ADMIN, FALSE))
 		observer = new /mob/dead/observer/admin(src)
 	else
 		observer = new /mob/dead/observer/rogue(src)

--- a/config/admin_ranks.txt
+++ b/config/admin_ranks.txt
@@ -60,7 +60,7 @@ Exclude =
 Edit =
 
 Name = Game Admin
-Include = @ STEALTH SOUND DEBUG
+Include = @ STEALTH SOUND DEBUG WATCH
 Exclude =
 Edit =
 


### PR DESCRIPTION
Uncomments some of the admin keybinds to hopefully make adminning less of a chore.
Adds the WATCH perm to the Game Admin rank so that aghosting spawns a true ghost and not the blackstone dead mob ghost.

Likely will continue working on improving admin tools and QOL in the future.