### PR TITLE
Makes it so that zombies cannot be made if the player count is less than 50

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -406,16 +406,21 @@ Works together with spawning an observer, noted above.
 	return ghost
 
 /mob/living/carbon/human/ghostize(can_reenter_corpse = 1, force_respawn = FALSE, drawskip = FALSE, admin = FALSE)
-	if(mind)
-		var/datum/antagonist/zombie/zomble = mind.has_antag_datum(/datum/antagonist/zombie)
-		if(zomble)
-			if(force_respawn)
-				mind.remove_antag_datum(/datum/antagonist/zombie)
-				return ..()
-			else if(!zomble.revived)
-				if(!(world.time % 5))
-					to_chat(src, span_warning("I'm preparing to walk again."))
-				return
+	if(mind) // check if we're a player
+		var/playercount = 0 // setup a var
+		for(var/client/C in GLOB.clients) //for every client in the game add one to the var
+			playercount++
+		if(playercount >= 50) // check the var to see if it's more than 50, if not just ghost the player
+			// turn us into a deadite flesh eater
+			var/datum/antagonist/zombie/zomble = mind.has_antag_datum(/datum/antagonist/zombie)
+			if(zomble)
+				if(force_respawn)
+					mind.remove_antag_datum(/datum/antagonist/zombie)
+					return ..()
+				else if(!zomble.revived)
+					if(!(world.time % 5))
+						to_chat(src, span_warning("I'm preparing to walk again..."))
+					return
 	return ..()
 
 /mob/proc/scry_ghost()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
when you die and try to rise as a zombie you get ghosted IF the there are less than 50 players, otherwise it acts as normal causing you to rise as a zombie.

## Why It's Good For The Game
zombies in thier current state are powerful, at population counts this small on the server, there are no combat roles to fight them as people are playing more mechanical focused roles.