### PR TITLE
removal of code that makes you rise as a zombie 5 minutes later after death()

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -45,13 +45,6 @@
 				dust(just_ash=TRUE,drop_items=TRUE)
 				return
 
-	if(!gibbed)
-		var/datum/antagonist/zombie/zomble = mind?.has_antag_datum(/datum/antagonist/zombie)
-		if(zomble)
-			addtimer(CALLBACK(zomble, TYPE_PROC_REF(/datum/antagonist/zombie, wake_zombie)), 5 SECONDS)
-		else if(can_death_zombify())
-			zombie_check()
-
 	if(client || mind)
 		SSticker.deaths++
 


### PR DESCRIPTION
ripping this out, why is there need for two checks that do the same thing? this one acts when you die and revives you 5 minutes later.