### PR TITLE
New Treasury Starting Amounts

### DIFF
--- a/code/controllers/subsystem/rogue/treasury.dm
+++ b/code/controllers/subsystem/rogue/treasury.dm
@@ -35,7 +35,13 @@ SUBSYSTEM_DEF(treasury)
 
 
 /datum/controller/subsystem/treasury/Initialize()
-	treasury_value = rand(800,1500)
+	var/playercount = 0 // setup a var to get the total player number
+	var/treasury_player_value = 15 // How much each person is worth.
+	for(var/client/C in GLOB.clients) // for every player add 1 to playercount
+		playercount++
+	treasury_value = round(rand((playercount * (treasury_player_value * 0.5)),(playercount * treasury_player_value))) // Based on 100 players having a 750 low, 1500 high.
+	if (treasury_value <= 99)
+		treasury_value = 100 - rand(1,9) // a floor of 100 with a few missing
 	queens_tax = pick(0.09, 0.15, 0.21, 0.30)
 
 	for(var/path in subtypesof(/datum/roguestock/bounty))
@@ -85,7 +91,7 @@ SUBSYSTEM_DEF(treasury)
 					send_ooc_note("Income from wealth horde: +[amt_to_generate]", name = X.real_name)
 					if(people_told > 3)
 						return
-			
+
 
 /datum/controller/subsystem/treasury/proc/create_bank_account(name, initial_deposit)
 	if(!name)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Treasury value is now based on the amount of players connected on treasury initialize. 
Old value was static random value between 800 & 1500.
New values are based on those old values when 100 players are connected. 
Value has a floor of 100 if the starting amount is less than that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Low pop rounds consisted of over 1,000 bucks in the vault, generating large amount of pay outs to the small amount of payees.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
