### PR TITLE
enables ROGUEMODE (Gamemodes & Antags)

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -88,7 +88,7 @@ NO_INTERCEPT_REPORT
 ## Default probablity is 1, increase to make that mode more likely to be picked.
 ## Set to 0 to disable that mode.
 
-PROBABILITY CHAOSMODE 99
+PROBABILITY ROGUEMODE 99
 PROBABILITY TRAITOR 0
 PROBABILITY TRAITORBRO 0
 PROBABILITY TRAITORCHAN 0


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
silly me, it was here the whole time
Picks gamemode and antags from the rules set in `code/game/gamemodes/roguetown/roguetown.dm`
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows players to become antags all on their own.
Available gamemodes and player counts needed:
Bandits - 10 Players
Rebels - 10 Players
Vamps & Werewolves - Number is set independently but involves a specific number of each type. ~3 Vamps / 1-2 Vulfs
Aspirants - No explicit player requirement.
Maniacs - No explicit player requirement.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
