### PR TITLE
Adjusting tiredness

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -86,4 +86,4 @@
 	var/stam_paralyzed = FALSE
 
 	var/domhand = 0
-	var/tiredness = 0
+	var/tiredness = 45 // we start a little tired 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -65,6 +65,7 @@
 						to_chat(src, span_warning("I'll fall asleep soon..."))
 					fallingas++
 					if(fallingas > 15)
+						tiredness = tiredness - 45 // Sleeping on a bed gives you about 5.5 hours
 						Sleeping(300)
 				else
 					rogstam_add(buckled.sleepy * 10)
@@ -75,12 +76,13 @@
 						to_chat(src, span_warning("I'll fall asleep soon, although a bed would be more comfortable..."))
 					fallingas++
 					if(fallingas > 25)
+						tiredness = tiredness - 25 // Sleeping without gives you about 2.5
 						Sleeping(300)
 				else
 					rogstam_add(10)
 			else if(fallingas)
 				fallingas = 0
-			tiredness = min(tiredness + 1, 100)
+			tiredness = min(tiredness + 0.33, 100)
 
 		handle_brain_damage()
 


### PR DESCRIPTION
there are three fatigue systems in the game, here's how they work
- rogfat, which is actually the green stamina bar 
-- the one that goes down when you run and recovers quickly
-- does not affect need to sleep
- rogstam, which is actually the blue fatigue bar
-- the one that goes down when you chop a tree and recovers when you lie down
-- does not affect need to sleep
- tiredness (the important one here), doesn't seem to have an indicator?
-- gets increased by 1 at every life tick, goes from 0 to 100 in about 3 IC hours
-- gives you the tired debuff at 21 IC time if tiredness >= 100
-- only way to reduce it is sleeping with the debuff

this PR changes
- tiredness increases by 0.33 every tick (around 9 IC hours from 0 to 100)
- (new) sleeping reduces tiredness, reducing more more if you sleep on a bed (bed 45; no bed 25)
- (new) characters start with 45 tiredness so they will likely have to sleep at the first night 

tldr you wont get the tired debuff if you slept a bit before nightfall