### PR TITLE
Shield and Flail Nerfs

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -17,7 +17,7 @@
 	swingsound = BLUNTWOOSH_MED
 	throwforce = 5
 	wdefense = 0
-	minstr = 4
+	minstr = 5
 
 /datum/intent/flail/strike
 	name = "strike"
@@ -25,7 +25,7 @@
 	attack_verb = list("strikes", "hits")
 	hitsound = list('sound/combat/hits/blunt/flailhit.ogg')
 	chargetime = 0
-	penfactor = 5
+	penfactor = 4
 	icon_state = "instrike"
 	item_d_type = "slash"
 
@@ -34,18 +34,18 @@
 	blade_class = BCLASS_BLUNT
 	attack_verb = list("strikes", "hits")
 	hitsound = list('sound/combat/hits/blunt/flailhit.ogg')
-	chargetime = 5
+	chargetime = 6
 	recovery = 15
-	penfactor = 5
+	penfactor = 4
 	reach = 2
 	icon_state = "instrike"
 	item_d_type = "slash"
 
 /datum/intent/flail/strike/smash
 	name = "smash"
-	chargetime = 5
+	chargetime = 6
 	no_early_release = TRUE
-	penfactor = 80
+	penfactor = 50
 	recovery = 10
 	damfactor = 1.5
 	chargedloop = /datum/looping_sound/flailswing
@@ -84,7 +84,7 @@
 
 
 /obj/item/rogueweapon/flail/sflail
-	force = 30
+	force = 25
 	icon_state = "flail"
 	desc = "This is a swift, steel flail. Strikes hard and far."
 	smeltresult = /obj/item/ingot/steel

--- a/code/game/objects/items/rogueweapons/shields.dm
+++ b/code/game/objects/items/rogueweapons/shields.dm
@@ -21,7 +21,7 @@
 	resistance_flags = FLAMMABLE
 	can_parry = TRUE
 	wdefense = 15
-	var/coverage = 90
+	var/coverage = 60
 	parrysound = "parrywood"
 	attacked_sound = "parrywood"
 	max_integrity = 150


### PR DESCRIPTION
Hits both Shields and Flails with some stat nerfs.

Community seems to regard them as extremely overpowered, namely shields having 90% coverage.
They're down to 50%.
Steel flails do less damage, and flail attacks in general have less pen and more charge time.

Lets see how these feel.