### PR TITLE
Makes the spirit tab go away when revived

### DIFF
--- a/code/modules/antagonists/roguetown/villain/zomble.dm
+++ b/code/modules/antagonists/roguetown/villain/zomble.dm
@@ -334,6 +334,7 @@
 		return FALSE
 	flash_fullscreen("redflash3")
 	to_chat(src, span_danger("ZIZO! I NEED TO DIG MY TEETH INTO FLESH!"))
+	src.client.verbs -= GLOB.ghost_verbs
 	emote("rage")
 	Knockdown(1)
 	zombie_antag.wake_zombie(TRUE)

--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -95,6 +95,7 @@
 		target.Jitter(100)
 		target.update_body()
 		target.visible_message(span_notice("[target] is revived by holy light!"), span_green("I awake from the void."))
+		target.client.verbs -= GLOB.ghost_verbs
 		if(target.mind)
 			if(revive_pq && !HAS_TRAIT(target, TRAIT_IWASREVIVED) && user?.ckey)
 				adjust_playerquality(revive_pq, user.ckey)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

fixes https://github.com/russ-money/subterra/issues/30

## About The Pull Request
makes it so that all the verbs that you get when you die go away upon revival such as priest spell or turning into a zombie

## Why It's Good For The Game
people being able to just go to the spirit world whenever they want after being revived is an oversight/bug
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
