### PR TITLE
Revert zombie changes

### DIFF
--- a/code/modules/antagonists/roguetown/villain/zomble.dm
+++ b/code/modules/antagonists/roguetown/villain/zomble.dm
@@ -34,6 +34,7 @@
 		TRAIT_NOPAIN,
 		TRAIT_NOPAINSTUN,
 		TRAIT_NOBREATH,
+		TRAIT_NOBREATH,
 		TRAIT_TOXIMMUNE,
 		TRAIT_CHUNKYFINGERS,
 		TRAIT_NOSLEEP,
@@ -43,7 +44,7 @@
 		TRAIT_LIMPDICK,
 		TRAIT_ZOMBIE_SPEECH,
 		TRAIT_ZOMBIE_IMMUNE,
-		//TRAIT_EMOTEMUTE,
+		TRAIT_EMOTEMUTE,
 		TRAIT_ROTMAN,
 		TRAIT_NORUN
 	)
@@ -186,24 +187,34 @@
 			zombie_part.rotted = TRUE
 		zombie_part.update_disabled()
 	zombie.update_body()
-	zombie.cmode_music = 'sound/music/combat_zombie.ogg'
+	zombie.cmode_music = 'sound/music/combat_weird.ogg'
 	zombie.set_patron(/datum/patron/inhumen/zizo)
 
-	// We will adjust thier stats so they're a bit stronger 
-	zombie.STASTR += rand(6,10)
-	if(zombie.STASTR >= 20)
-		zombie.STASTR = 20
-	zombie.STACON += rand(6,10)
-	if(zombie.STACON >= 20)
-		zombie.STACON = 20
-	zombie.STASPD = rand(3,6)
+	// Outside of one 2% chance remaining for zombie era strength
+	if(prob(2))
+		zombie.STASTR = 18
+
+	// This is the original first commit values for it, aka 5-7
+	zombie.STASPD = rand(5,7)
+
 	zombie.STAINT = 1
-	
 	last_bite = world.time
 	has_turned = TRUE
+	// Drop your helm and gorgies boy you won't need it anymore!!!
+	var/static/list/removed_slots = list(
+		SLOT_HEAD,
+		SLOT_WEAR_MASK,
+		SLOT_MOUTH,
+		SLOT_NECK,
+	)
+	for(var/slot in removed_slots)
+		zombie.dropItemToGround(zombie.get_item_by_slot(slot), TRUE)
+
+	// Ghosts you because this shit was just not working whatsoever, let the AI handle the rest
+	zombie.ghostize(FALSE)
 
 /datum/antagonist/zombie/greet()
-	to_chat(owner.current, span_userdanger("Death is not the end... We must spread..."))
+	to_chat(owner.current, span_userdanger("Death is not the end..."))
 	return ..()
 
 /datum/antagonist/zombie/on_life(mob/user)
@@ -290,7 +301,7 @@
 	if(!closest_dist)
 		to_chat(src, span_warning("I failed to smell anything..."))
 		return FALSE
-	to_chat(src, span_warning("I smell something... [closest_dist] meters away, [dir2text(the_dir)]..."))
+	to_chat(src, span_warning("[closest_dist] meters away, [dir2text(the_dir)]..."))
 	return TRUE
 
 /// Use this to attempt to add the zombie antag datum to a human
@@ -323,9 +334,7 @@
 	to_chat(src, span_danger("I feel horrible... REALLY horrible..."))
 	mob_timers["puke"] = world.time
 	vomit(1, blood = TRUE, stun = FALSE)
-	src.playsound_local(get_turf(src), 'sound/music/horror.ogg', 35, FALSE, pressure_affected = FALSE, channel = CHANNEL_MUSIC)
-	vomit(blood = TRUE, stun = FALSE)
-	addtimer(CALLBACK(src, PROC_REF(wake_zombie)), 125 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(wake_zombie)), 1 MINUTES)
 	return zombie_antag
 
 /mob/living/carbon/human/proc/wake_zombie()
@@ -333,9 +342,8 @@
 	if(!zombie_antag || zombie_antag.has_turned)
 		return FALSE
 	flash_fullscreen("redflash3")
-	to_chat(src, span_danger("ZIZO! I NEED TO DIG MY TEETH INTO FLESH!"))
-	src.client.verbs -= GLOB.ghost_verbs
-	emote("rage")
+	to_chat(src, span_danger("It hurts... Is this really the end for me?"))
+	emote("scream") // heres your warning to others bro
 	Knockdown(1)
 	zombie_antag.wake_zombie(TRUE)
 	return TRUE

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -406,22 +406,16 @@ Works together with spawning an observer, noted above.
 	return ghost
 
 /mob/living/carbon/human/ghostize(can_reenter_corpse = 1, force_respawn = FALSE, drawskip = FALSE, admin = FALSE)
-	if(mind) // check if we are a player
-		var/playercount = 0 // setup a var to get the total player number
-		for(var/client/C in GLOB.clients) // for every player add 1 to playercount
-			playercount++
-		testing("GHOSTIZE(Mob:[src])(PlayerTotal:[playercount])")
-		if(playercount >= 40) // if we have 40 or more players turn us into a zombie
-			var/datum/antagonist/zombie/zomble = mind.has_antag_datum(/datum/antagonist/zombie)
+	if(mind)
+		var/datum/antagonist/zombie/zomble = mind.has_antag_datum(/datum/antagonist/zombie)
+		if(zomble)
 			if(force_respawn)
 				mind.remove_antag_datum(/datum/antagonist/zombie)
 				return ..()
 			else if(!zomble.revived)
 				if(!(world.time % 5))
-					to_chat(src, span_warning("I'm preparing to walk again..."))
+					to_chat(src, span_warning("I'm preparing to walk again."))
 				return
-		else
-			return ..()
 	return ..()
 
 /mob/proc/scry_ghost()

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -45,6 +45,13 @@
 				dust(just_ash=TRUE,drop_items=TRUE)
 				return
 
+	if(!gibbed)
+		var/datum/antagonist/zombie/zomble = mind?.has_antag_datum(/datum/antagonist/zombie)
+		if(zomble)
+			addtimer(CALLBACK(zomble, TYPE_PROC_REF(/datum/antagonist/zombie, wake_zombie)), 5 SECONDS)
+		else if(can_death_zombify())
+			zombie_check()
+
 	if(client || mind)
 		SSticker.deaths++
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Zombie PCs are not working as intended.
- When player count did not meet the threshold, NPC zombies would rez with no logic. (Comatose mobs)
- Players were not able to rez as a zombie when the player threshold was met.
- Players were having issues ghosting into a spirit when they died.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I like the idea of PC zombies however, I would like this feature to be in a better working state with more balance behind it before we attempt this in the future. I prefer we have something working than a broken aspect.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
