### PR TITLE
Nightvision

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/_dwarf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/_dwarf.dm
@@ -5,6 +5,7 @@
 	name = "Dwarfb"
 	id = "dwarf"
 	max_age = 200
+	mutanteyes = /obj/item/organ/eyes/light_sensitive
 
 /datum/species/dwarf/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	..()

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -154,6 +154,12 @@
 	see_in_dark = 3
 	lighting_alpha = LIGHTING_PLANE_ALPHA_LESSER_NV_TRAIT
 
+/obj/item/organ/eyes/light_sensitive
+	name = "light-sensitive eyes"
+	desc = ""
+	see_in_dark = 4
+	lighting_alpha = LIGHTING_PLANE_ALPHA_LESSER_NV_TRAIT
+
 /obj/item/organ/eyes/goblin
 	name = "goblin eyes"
 	desc = ""


### PR DESCRIPTION
## About The Pull Request

Per the code bounty request.
Adds a basic nightvision to Dwarf species.
All elves already got good nightvision.

The actual ingame effect can be seen  below.
Top is human, middle is the basic nightivision
Bottom is the good one. Easy enough to adjust as desired.

![BOUNTYNITE](https://github.com/user-attachments/assets/29a322ce-3c1f-4179-8a8f-e791b8c990cc)
