### PR TITLE
Put a player cap on the lights out event to prevent it from running without people to fix the lights.

### DIFF
--- a/code/modules/events/rogue/lightsout.dm
+++ b/code/modules/events/rogue/lightsout.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/rogue/lightsout
 	weight = 5
 	max_occurrences = 1
-	min_players = 0
+	min_players = 5
 	req_omen = TRUE
 	todreq = list("dusk", "night")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Salt PR, mainly because I find it obnoxious to try and latejoin when the entire kingdom is in darkness. Between the color scheme and the day/night cycle, you will be blind for half of the round if the lights out event has fired at any point before people are around. This is detrimental both for RP and general gameplay.
## Why It's Good For The Game

Being in the dark because your king died? great omen. Being in the dark because there was nobody to serve as king to begin with? Agony.